### PR TITLE
Propagate snow depth texture to VHM

### DIFF
--- a/Plugins/UnrealSnow/Source/UnrealSnow/Public/Simulation/SnowSimulationActor.h
+++ b/Plugins/UnrealSnow/Source/UnrealSnow/Public/Simulation/SnowSimulationActor.h
@@ -208,10 +208,14 @@ protected:
 	UMaterialInstanceDynamic* SnowWriterMID = nullptr;
 
 	// VHM material binding convenience (user-specified material instance on VHM)
-	UPROPERTY()
-	UMaterialInstanceDynamic* SnowMID = nullptr;
-	UPROPERTY()
-	AActor* BoundVHMActor = nullptr;
+        UPROPERTY()
+        UMaterialInstanceDynamic* SnowMID = nullptr;
+        UPROPERTY()
+        AActor* BoundVHMActor = nullptr;
+
+        // Cached MIDs for all bound VHMs to push updated textures each step
+        UPROPERTY()
+        TArray<TWeakObjectPtr<UMaterialInstanceDynamic>> BoundVHMMIDs;
 
 	// --- Procedural snow surface mesh ---
 // No UPROPERTY for legacy procedural mesh; keep a private raw pointer below


### PR DESCRIPTION
## Summary
- Cache material instances for Virtual Heightfield Mesh components to ensure snow textures are updated
- Update cached materials after redistribution to pass current and previous snow depth textures

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af254538708331ab663324ee90fc70